### PR TITLE
fix: ゲームオーバー時に最終スコアと再プレイボタンが表示されない問題を修正

### DIFF
--- a/src/app/components/GameStateManager.tsx
+++ b/src/app/components/GameStateManager.tsx
@@ -22,7 +22,7 @@ export const GameStateManager = ({
 }: GameStateManagerProps) => {
   const { t } = useTranslation();
   
-  if (currentRound) {
+  if (currentRound && !isGameOver) {
     return (
       <>
         <GameBoard round={currentRound} onGuess={onGuess} />


### PR DESCRIPTION
## 概要
- ゲームオーバー時に最終スコアと「もう一度プレイ」ボタンが表示されない問題を修正しました
- GameStateManagerコンポーネントの条件分岐を修正

## 問題の原因
ゲームオーバー時でも`currentRound`が存在し続けるため、`if (currentRound)`の条件が真となり、ゲームボード画面が表示され続けていました。

## 変更内容
条件分岐に`\!isGameOver`を追加：
```typescript
// 修正前
if (currentRound) {

// 修正後  
if (currentRound && \!isGameOver) {
```

## テスト結果
- ✅ TypeScriptの型チェック: エラーなし
- ✅ Biomeのコードチェック: エラーなし
- ✅ 全テスト（80テスト）: パス

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The game board and controls are now hidden when the game is over, ensuring only the game over screen is displayed at the end of a game.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->